### PR TITLE
Add retresco endpoint specification

### DIFF
--- a/livingdocs-openapi.json
+++ b/livingdocs-openapi.json
@@ -117,6 +117,14 @@
         "description": "Docs",
         "url": "docs.livingdocs.io/reference-docs/public-api/status/"
       }
+    },
+    {
+      "name": "Retresco",
+      "description": "Retresco Webhook",
+      "externalDocs": {
+        "description": "Docs",
+        "url": "docs.livingdocs.io/guides/integrations/retresco/"
+      }
     }
   ],
   "paths": {
@@ -3916,9 +3924,9 @@
           }
         ],
         "tags": [
-          "Retresco re-enrich"
+          "Retresco"
         ],
-        "summary": "Retresco hook",
+        "summary": "Retresco re-enrich Webhook",
         "description": "This hook should be used on Retresco when enabling the re-enrich feature to trigger asynchronous document enrichment.",
         "requestBody": {
           "content": {

--- a/livingdocs-openapi.json
+++ b/livingdocs-openapi.json
@@ -3906,6 +3906,57 @@
         }
       }
     },
+    "/api/v1/retresco/re-enrich": {
+      "post": {
+        "security": [
+          {
+            "bearerAuth": [
+              "retresco"
+            ]
+          }
+        ],
+        "tags": [
+          "Retresco re-enrich"
+        ],
+        "summary": "Retresco hook",
+        "description": "This hook should be used on Retresco when enabling the re-enrich feature to trigger asynchronous document enrichment.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "example": {
+                  "doc_ids": [1, 2, 3, 4]
+                },
+                "required": [
+                  "doc_ids"
+                ],
+                "properties": {
+                  "doc_ids": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "doc_ids list accepted to process"
+          }
+        }
+      }
+    },
     "/api/beta/composition/{documentId}": {
       "post": {
         "security": [


### PR DESCRIPTION
Relations:
  - Documentation: https://github.com/livingdocsIO/documentation/pull/620
  - Issue: https://3.basecamp.com/4910529/buckets/29891492/todolists/5478483998
  - Related PRs: https://github.com/livingdocsIO/livingdocs-editor/pull/6367
  - Related PRs: https://github.com/livingdocsIO/livingdocs-server/pull/5254

Added a new endpoint for retresco exposed via the public api. This endpoint is a hook for retresco that accepts an array of documents and starts job queue to re-enrich all the specified documents.