### PR TITLE
Incoming draft references endpoint

### DIFF
--- a/livingdocs-openapi.json
+++ b/livingdocs-openapi.json
@@ -47,14 +47,6 @@
       }
     },
     {
-      "name": "Search",
-      "description": "Search",
-      "externalDocs": {
-        "description": "Docs",
-        "url": "https://docs.livingdocs.io/reference/public-api/search/"
-      }
-    },
-    {
       "name": "Document Lists",
       "description": "",
       "externalDocs": {
@@ -300,7 +292,7 @@
           }
         ],
         "tags": [
-          "Search"
+          "Publications"
         ],
         "operationId": "searchPublications",
         "summary": "Search Publications",

--- a/livingdocs-openapi.json
+++ b/livingdocs-openapi.json
@@ -3022,7 +3022,7 @@
           }
         ],
         "tags": [
-          "Publications"
+          "Drafts"
         ],
         "operationId": "getLatestDraftForDocument",
         "summary": "Get Latest Draft",
@@ -3118,6 +3118,95 @@
                       }
                     ]
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/drafts/{documentId}/incomingDocumentReferences": {
+      "get": {
+        "security": [
+          {
+            "bearerAuth": [
+              "public-api:drafts:read"
+            ]
+          }
+        ],
+        "tags": [
+          "Drafts"
+        ],
+        "operationId": "getIncomingDraftReferences",
+        "summary": "Get Incoming Draft References for a Document",
+        "description": "This endpoint is functionally equivalent to the incoming document references endpoint for publications. But with this draft endpoint you will receive references from unpublished documents as well as references from the current state of documents even if these latest updates to the document are not published yet.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "schema": {
+              "type": "integer"
+            },
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "limit",
+            "description": "A limit for how much documents to retrieve. Defaults to 100. Max. 100.",
+            "schema": {
+              "type": "integer",
+              "example": "100"
+            },
+            "in": "query"
+          },
+          {
+            "name": "offset",
+            "description": "An offset into the query. Useful when getting more than 100 results (pagination).",
+            "schema": {
+              "type": "integer",
+              "example": "0"
+            },
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "example": [
+                    {
+                      "id": 4,
+                      "references": [
+                        {
+                          "id": "1",
+                          "type": "document",
+                          "location": "include-directive",
+                          "componentId": "doc-1euiflvoq0",
+                          "serviceName": "editable-teaser",
+                          "propertyName": "article",
+                          "componentName": "teaser-include",
+                          "directiveName": "teaser"
+                        }
+                      ]
+                    },
+                    {
+                      "id": 2,
+                      "references": [
+                        {
+                          "id": "1",
+                          "type": "document",
+                          "location": "include-directive",
+                          "componentId": "doc-1eu6i7l880",
+                          "serviceName": "editable-teaser",
+                          "propertyName": "article",
+                          "componentName": "teaser-include",
+                          "directiveName": "teaser"
+                        }
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -4350,10 +4439,6 @@
   },
   "servers": [
     {
-      "url": "https://server.livingdocs.io",
-      "description": "demo"
-    },
-    {
       "url": "http://localhost:9090",
       "description": "localhost"
     },
@@ -4372,6 +4457,10 @@
           "default": "example.com"
         }
       }
+    },
+    {
+      "url": "https://server.livingdocs.io",
+      "description": "demo"
     }
   ],
   "components": {


### PR DESCRIPTION
- add /api/v1/drafts/{documentId}/incomingDocumentReferences endpoint
- change categories (tags) to reflect documentation